### PR TITLE
chore: Remove outdated irrelevant gene/bluefoot conflict

### DIFF
--- a/app/code/Magento/PageBuilder/composer.json
+++ b/app/code/Magento/PageBuilder/composer.json
@@ -27,9 +27,6 @@
     "suggest": {
         "magento/module-review": "*"
     },
-    "conflict": {
-        "gene/bluefoot": "*"
-    },
     "type": "magento2-module",
     "license": [
         "proprietary"


### PR DESCRIPTION
Removes `gene/bluefoot` conflict from `composer.json`

At original release, many years ago, this prevented use of Page Builder at the same time as the Bluefoot CMS module it was based on. But I highly doubt that module even exists anymore in any form, so there's no particular reason for us to keep this rule.