### PR TITLE
Update composer.json to remove analytics modules

### DIFF
--- a/app/code/Magento/_metapackage/composer.json
+++ b/app/code/Magento/_metapackage/composer.json
@@ -3,10 +3,7 @@
     "description": "Page Builder metapackage",
     "require": {
         "magento/module-page-builder": "*",
-        "magento/module-page-builder-analytics": "*",
-        "magento/module-cms-page-builder-analytics": "*",
         "magento/module-page-builder-admin-analytics": "*",
-        "magento/module-catalog-page-builder-analytics": "*",
         "magento/module-aws-s3-page-builder": "*",
         "magento/module-page-builder-image-attribute": "*"
     },


### PR DESCRIPTION
This removes the module-analytics submodules from page-builder. This is data reporting that isn't used by and doesn't matter to Mage-OS.

Should be merged in advance of the release of Mage-OS 3.0.

Related to https://github.com/mage-os/mageos-magento2/issues/202